### PR TITLE
各モデル・テーブルの作成

### DIFF
--- a/app/models/correction.rb
+++ b/app/models/correction.rb
@@ -1,0 +1,3 @@
+class Correction < ApplicationRecord
+  belongs_to :document
+end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -1,0 +1,2 @@
+class Document < ApplicationRecord
+end

--- a/app/models/expected_question.rb
+++ b/app/models/expected_question.rb
@@ -1,0 +1,2 @@
+class ExpectedQuestion < ApplicationRecord
+end

--- a/app/models/interview_sheet.rb
+++ b/app/models/interview_sheet.rb
@@ -1,0 +1,2 @@
+class InterviewSheet < ApplicationRecord
+end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -1,0 +1,2 @@
+class Movie < ApplicationRecord
+end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -1,0 +1,2 @@
+class Text < ApplicationRecord
+end

--- a/db/migrate/20200920074243_create_texts.rb
+++ b/db/migrate/20200920074243_create_texts.rb
@@ -1,0 +1,10 @@
+class CreateTexts < ActiveRecord::Migration[6.0]
+  def change
+    create_table :texts do |t|
+      t.string :title
+      t.text :content
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200920075314_create_movies.rb
+++ b/db/migrate/20200920075314_create_movies.rb
@@ -1,0 +1,10 @@
+class CreateMovies < ActiveRecord::Migration[6.0]
+  def change
+    create_table :movies do |t|
+      t.string :title
+      t.string :url
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200920080036_create_interview_sheets.rb
+++ b/db/migrate/20200920080036_create_interview_sheets.rb
@@ -1,0 +1,10 @@
+class CreateInterviewSheets < ActiveRecord::Migration[6.0]
+  def change
+    create_table :interview_sheets do |t|
+      t.string :title
+      t.text :content
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200920080213_create_expected_questions.rb
+++ b/db/migrate/20200920080213_create_expected_questions.rb
@@ -1,0 +1,10 @@
+class CreateExpectedQuestions < ActiveRecord::Migration[6.0]
+  def change
+    create_table :expected_questions do |t|
+      t.string :title
+      t.text :content
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200920080304_create_documents.rb
+++ b/db/migrate/20200920080304_create_documents.rb
@@ -1,0 +1,10 @@
+class CreateDocuments < ActiveRecord::Migration[6.0]
+  def change
+    create_table :documents do |t|
+      t.string :title
+      t.text :content
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200920081356_create_corrections.rb
+++ b/db/migrate/20200920081356_create_corrections.rb
@@ -1,0 +1,10 @@
+class CreateCorrections < ActiveRecord::Migration[6.0]
+  def change
+    create_table :corrections do |t|
+      t.references :document, null: false, foreign_key: true
+      t.text :content
+
+      t.timestamps
+    end
+  end
+end

--- a/test/fixtures/corrections.yml
+++ b/test/fixtures/corrections.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  document: one
+  content: MyText
+
+two:
+  document: two
+  content: MyText

--- a/test/fixtures/documents.yml
+++ b/test/fixtures/documents.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  title: MyString
+  content: MyText
+
+two:
+  title: MyString
+  content: MyText

--- a/test/fixtures/expected_questions.yml
+++ b/test/fixtures/expected_questions.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  title: MyString
+  content: MyText
+
+two:
+  title: MyString
+  content: MyText

--- a/test/fixtures/interview_sheets.yml
+++ b/test/fixtures/interview_sheets.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  title: MyString
+  content: MyText
+
+two:
+  title: MyString
+  content: MyText

--- a/test/fixtures/movies.yml
+++ b/test/fixtures/movies.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  title: MyString
+  url: MyString
+
+two:
+  title: MyString
+  url: MyString

--- a/test/fixtures/texts.yml
+++ b/test/fixtures/texts.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  title: MyString
+  content: MyText
+
+two:
+  title: MyString
+  content: MyText

--- a/test/models/correction_test.rb
+++ b/test/models/correction_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class CorrectionTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/document_test.rb
+++ b/test/models/document_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class DocumentTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/expected_question_test.rb
+++ b/test/models/expected_question_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ExpectedQuestionTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/interview_sheet_test.rb
+++ b/test/models/interview_sheet_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class InterviewSheetTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/movie_test.rb
+++ b/test/models/movie_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class MovieTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/text_test.rb
+++ b/test/models/text_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class TextTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 内容
- Textモデルとtextsテーブルを作成
    - カラムは「`title`（`string型`）」「`content`（`text型`）」

- Movieモデルとmoviesテーブルを作成
     - カラムは「`title`（`string型`） 」と「`url`（`string型`）」

- InterviewSheetモデルとinterview_sheetsテーブルを作成
    - カラムは「`title`（`string型`）」「`content`（`text型`）」

- ExpectedQuestionモデルとexpected_questionsテーブルを作成
    - カラムは「`title`（`string型`）」「`content`（`text型`）」

- Documentモデルとdocumentsテーブルを作成
    - カラムは「`title`（`string型`）」「`content`（`text型`）」

- Correctionモデルとcorrectionsテーブルを作成
    - カラムは「`document`（`references型`）」「`content`（`text型`）」

## 参考資料
RailsのDBモデルの命名規則をまとめてみた
https://qiita.com/seri1234/items/8ca4b52d82390929195f
【Rails】外部キー追加におけるreference型の使用、未使用の違い。外部キー制約によるエラーをコンソールで確認してみた。
https://qiita.com/kents1002/items/661605753a5f6c56ffc3