### PR TITLE
15_テキスト教材詳細ページの実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,8 @@ gem 'devise'
 gem 'rails-i18n'
 gem 'devise-i18n'
 gem 'devise-bootstrap-views'
+gem 'redcarpet', '~>2.3.0'
+gem 'coderay'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,6 +155,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redcarpet (2.3.0)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -211,6 +212,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (>= 1.4.2)
   byebug
+  coderay
   devise
   devise-bootstrap-views
   devise-i18n
@@ -223,6 +225,7 @@ DEPENDENCIES
   puma (~> 4.1)
   rails (~> 6.0.3)
   rails-i18n
+  redcarpet (~> 2.3.0)
   sass-rails (>= 6)
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -48,3 +48,8 @@ body {
   }
 
   }
+
+  /* テキスト教材ページ */
+  #text-contents h2 {
+    font-weight: bold;
+  } 

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -3,4 +3,8 @@ class TextsController < ApplicationController
     @texts = Text.all
   end
 
+  def show
+    @text = Text.find(params[:id])
+  end
+
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,50 @@
 module ApplicationHelper
+
+  require "redcarpet"
+  require "coderay"
+
+  class HTMLwithCoderay < Redcarpet::Render::HTML
+    def block_code(code, language)
+      language = language.split(':')[0] if language.present?
+
+      case language.to_s
+      when 'rb'
+        lang = :ruby
+      when 'yml'
+        langu = :yaml
+      when 'css'
+        lang = :css
+      when 'html'
+        lang = :html
+      when ''
+        lang = :md
+      else
+        lang = language
+      end
+
+      CodeRay.scan(code, lang).div
+    end
+  end
+
+  def markdown(text)
+    html_render = HTMLwithCoderay.new(
+      filter_html: true,
+      hard_wrap: true,
+      link_attributes: { rel: 'nofollow', target: "_blank"}
+    )
+    options = {
+      autolink: true,
+      space_after_headers: true,
+      no_intra_emphasis: true,
+      fenced_code_blocks: true,
+      tables: true,
+      hard_wrap: true,
+      xhtml: true,
+      lax_html_blocks: true,
+      strikethrough: true
+    }
+    markdown = Redcarpet::Markdown.new(html_render, options)
+    markdown.render(text)
+  end
+
 end

--- a/app/views/texts/show.html.erb
+++ b/app/views/texts/show.html.erb
@@ -1,0 +1,9 @@
+<div class="text-container">
+  <section id="text-contents" class="mx-auto" style="700px;">
+
+    <h2 class="mt-5"><%= markdown(@text.title).html_safe %></h2>
+    <%= markdown(@text.content).html_safe %>
+
+  </section>
+
+</div>


### PR DESCRIPTION
## 内容
- markdownの導入
-  詳細ページの作成、記述
    - Markdownに対応した表示ができるようにする
## 参考資料
【rails】Markdown記法で投稿を表示する方法をやってみる
https://qiita.com/kaino5454/items/8b810ebc2d5236b8f812