### PR TITLE
16_動画教材のrakeタスクを実装

### DIFF
--- a/db/csv_data/movie_data.csv
+++ b/db/csv_data/movie_data.csv
@@ -1,0 +1,5 @@
+title,url
+面接再現（個別面接・特別区編）,https://www.youtube.com/watch?v=cnW8scGyYfk
+入退室のマナー,https://www.youtube.com/watch?v=rtoyXZ5HX0o
+バーチャル面トレ400,https://www.youtube.com/watch?v=2vcYNx810Rg
+2020年度の特別区試験状況,https://www.youtube.com/watch?v=BSDlefxLJlQ

--- a/lib/tasks/import_csv.rake
+++ b/lib/tasks/import_csv.rake
@@ -17,4 +17,19 @@ namespace :import_csv do
     end
   end
 
+  desc "動画教材のCSVデータをインポートするタスク"
+
+  task movie_data: :environment do
+    list = Import.csv_data(path:"db/csv_data/movie_data.csv")
+
+    puts START
+    # インポートができなかった場合の例外処理
+    begin
+      Movie.create!(list)
+      puts "インポート完了!!"
+    rescue ActiveModel::UnknownAttributeError => invalid
+      puts "インポートに失敗：UnknownAttributeError"
+    end
+  end
+
 end


### PR DESCRIPTION
## 内容
-  `movie_data.csv` を作成し、 `db/csv_data` ディレクトリに追加
-   import.rbを使用し、rakeタスクで `movie_data.csv` を `movies` テーブルにインポートする