### PR TITLE
添削ページにユーザー名が表示されるようにする

### DIFF
--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -1,10 +1,11 @@
 ActiveAdmin.register User do
-  permit_params :email, :password, :password_confirmation
+  permit_params :email, :password, :password_confirmation, :username
 
   index do
     selectable_column
     id_column
     column :email
+    column :username
     column :current_sign_in_at
     column :sign_in_count
     column :created_at
@@ -19,6 +20,7 @@ ActiveAdmin.register User do
   form do |f|
     f.inputs do
       f.input :email
+      f.input :username
       f.input :password
       f.input :password_confirmation
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,15 @@
 class ApplicationController < ActionController::Base
   before_action :authenticate_user!
+  
+  protect_from_forgery with: :exception
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  protected
+
+  def configure_permitted_parameters
+    added_attrs = [ :email, :username, :password, :password_confirmation ]
+    devise_parameter_sanitizer.permit :sign_up, keys: added_attrs
+    devise_parameter_sanitizer.permit :account_update, keys: added_attrs
+    devise_parameter_sanitizer.permit :sign_in, keys: added_attrs
+  end
 end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -12,6 +12,11 @@
         </div>
 
         <div class="form-group">
+          <%= f.label :お名前 %>
+          <%= f.text_field :username, class: 'form-control' %>
+        </div>
+
+        <div class="form-group">
           <%= f.label :password %>
           <%= f.password_field :password, autocomplete: 'current-password', class: 'form-control' %>
 

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -23,7 +23,8 @@
             <div class="row document">
               <div class="col-md-7 title"><%= document.title.truncate(50) %></div>
               <div class="col-md-5 info">
-                <p class="d-flex justify-content-end">申請日 <%= document.created_at.to_s(:datetime_jp) %></p>
+                <p class="d-flex justify-content-start">申請日 <%= document.created_at.to_s(:datetime_jp) %></p>
+                <p class="d-flex justify-content-start">申請者 <%= document.user.username %></p>
               </div>
             </div>
           <% end %>

--- a/app/views/documents/show.html.erb
+++ b/app/views/documents/show.html.erb
@@ -8,6 +8,7 @@
     <div class="detail pt-5">
       <h5>【原稿文章】</h5>
       <%= markdown(@document.content).html_safe %>
+      <p class="d-flex justify-content-end">申請者：<%= @document.user.username %></p>
     </div>
     <hr>
     <div class="d-flex justify-content-end">
@@ -18,7 +19,8 @@
       <% @document.corrections.each do |correction| %>
         <h5>【添削後の文章】</h5>  
         <%= markdown(correction.content).html_safe %> 
-      <p><%= correction.user.id %></p>
+        <p class="d-flex justify-content-end">添削者：<%= correction.user.username %></p>
+        <hr>
       <% end %>
     </div>
   </section>

--- a/db/migrate/20200929124605_add_username_to_users.rb
+++ b/db/migrate/20200929124605_add_username_to_users.rb
@@ -1,0 +1,5 @@
+class AddUsernameToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :username, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_29_041723) do
+ActiveRecord::Schema.define(version: 2020_09_29_124605) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -99,6 +99,7 @@ ActiveRecord::Schema.define(version: 2020_09_29_041723) do
     t.datetime "remember_created_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "username"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
## 内容
-  usersテーブルにusernameカラムを追加
-  アカウント新規登録時にemailとパスワードとともに名前も入力してもらい、usersテーブルに保存する
-  管理者画面からユーザーの名前を追加できるようにする
-  添削申請した人と添削した人の名前を表示させる
## 参考資料
deviseで作成したUserモデルにusernameカラムを追加してDBへ登録できるようにする
https://qiita.com/hz1_d/items/77e440b09a1ddbe56263
justify-content
https://developer.mozilla.org/ja/docs/Web/CSS/justify-content